### PR TITLE
Fixing filtering issue when a user that is assigned a Profile tries to apply additional filters.

### DIFF
--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -97,26 +97,8 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                 }
                 Map<String,List<String>> profileTagMap = parseTags(profileTags);
 
-                //set tag from input filter
-                Map<String,List<String>> tagMap = profileTagMap;
-                if (StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_TAG))) {
-                    //if manager allow any filter
-                    Map<String,List<String>> filterTags = new HashMap<>();
-                    if(Auth.MANAGER.equals(userType)) {
-                        filterTags.putAll(parseTags(Arrays.asList(sortedSet.getFilterMap().get(FILTER_BY_TAG))));
-                    //check against profile
-                    } else {
-                        Map<String,List<String>> tmpMap = parseTags(Arrays.asList(sortedSet.getFilterMap().get(FILTER_BY_TAG)));
-                        for(String name : tmpMap.keySet()) {
-                            if(profileTagMap.get(name).containsAll(tmpMap.get(name))) {
-                                filterTags.put(name,tmpMap.get(name));
-                            }
-                        }
-                    }
-                    if(filterTags.size() > 0){
-                        tagMap = filterTags;
-                    }
-                }
+                //set tags from input filters
+                Map<String, List<String>> filterTags = fetchInputFilterTags(userType, profileTagMap);
 
                 //parse out security group list in format group[,group]
                 List<String> securityGroupList = new ArrayList<>();
@@ -164,14 +146,13 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                             }
                             //set name value pair for tag filter
                             List<String> tagList = new ArrayList<String>();
-                            for (String tag : tagMap.keySet()) {
-                                if(tagMap.get(tag) != null) {
-                                    Filter tagValueFilter = new Filter("tag:" + tag, tagMap.get(tag));
-                                    describeInstancesRequest.withFilters(tagValueFilter);
-                                } else {
-                                    tagList.add(tag);
-                                }
-                            }
+
+                            //always add all profile tags to filter list
+                            addTagsToDescribeInstanceRequest(profileTagMap, describeInstancesRequest, tagList);
+
+                            //add all additional filter tags provided by the user
+                            addTagsToDescribeInstanceRequest(filterTags, describeInstancesRequest, tagList);
+
                             if (tagList.size() > 0) {
                                 Filter tagFilter = new Filter("tag-key", tagList);
                                 describeInstancesRequest.withFilters(tagFilter);
@@ -300,23 +281,53 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                 sortedSet = SystemDB.getSystemSet(sortedSet, new ArrayList<String>(hostSystemList.keySet()));
 
             }
-        } catch (
-                AmazonServiceException ex
-                )
-
-        {
+        } catch (AmazonServiceException ex) {
             log.error(ex.toString(), ex);
         }
 
 
-        if (script != null && script.getId() != null)
-
-        {
+        if (script != null && script.getId() != null) {
             script = ScriptDB.getScript(script.getId(), userId);
         }
 
-
         return SUCCESS;
+    }
+
+    private Map<String, List<String>> fetchInputFilterTags(String userType, Map<String, List<String>> profileTagMap) {
+        Map<String,List<String>> filterTags = new HashMap<>();
+        if (StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_TAG))) {
+            //if manager allow any filter
+            if(Auth.MANAGER.equals(userType)) {
+                filterTags.putAll(parseTags(Arrays.asList(sortedSet.getFilterMap().get(FILTER_BY_TAG))));
+            //check against profile
+            } else {
+                Map<String,List<String>> tmpMap = parseTags(Arrays.asList(sortedSet.getFilterMap().get(FILTER_BY_TAG)));
+                for(String name : tmpMap.keySet()) {
+
+                    //if profile tags does not have the filtered tag add to filters and it would be ANDed with profile tags.
+                    if(profileTagMap.get(name) == null) {
+                        filterTags.put(name,tmpMap.get(name));
+                    }
+
+                    //if profile tags have the filtered tag add to filters only if values are contained in allowed list of the user.
+                    if(profileTagMap.get(name) != null && profileTagMap.get(name).containsAll(tmpMap.get(name))) {
+                        filterTags.put(name,tmpMap.get(name));
+                    }
+                }
+            }
+        }
+        return filterTags;
+    }
+
+    private void addTagsToDescribeInstanceRequest(Map<String, List<String>> profileTagMap, DescribeInstancesRequest describeInstancesRequest, List<String> tagList) {
+        for (String tag : profileTagMap.keySet()) {
+            if(profileTagMap.get(tag) != null) {
+                Filter tagValueFilter = new Filter("tag:" + tag, profileTagMap.get(tag));
+                describeInstancesRequest.withFilters(tagValueFilter);
+            } else {
+                tagList.add(tag);
+            }
+        }
     }
 
     @Action(value = "/admin/saveSystem",


### PR DESCRIPTION
Lets assume we have the following two tags assigned to instances :

Environment (with values Prod, Sit and Uat)
Role (with values App1, App2 and App3)

**The issue** :
1)

If we have a Profile like - **Role=App1,Role=App2**

When the user assigned the Profile tries to filter with Environment=Sit it results in an error.

This is because of the if condition in the "//set tag from input filter" block where we are trying to acertain if the user has the tag in profileTag

"if(profileTagMap.get(name).containsAll(tmpMap.get(name)))"

The condition fails as the profile does not have Environment tag in it and this results in a null pointer exception.

Expected Behavior : On filtering with "Environment=Sit" the user should be shown all servers with Role App1,App2 in Environment Sit.

2) 

If we have a Profile like - **Environment=Sit,Role=App1,Role=App2**

When the user assigned the Profile tries to filter with Environment=Sit it results in listing out all instances with tag Environment=Sit not just the ones with Role as App1 and App2. This is a security issue.

This happens because the tags sent to AWS only has the Input Tags as they are overwritten in the below line in SystemAction :

if(filterTags.size() > 0){
    tagMap = filterTags;
}


The Fix submitted in this pull request :

1) When a Profile is associated to a users profile we should always add the ProfileTags to the AWS filter criteria. As of now the profile filters was replaced with the Input Filters that not only caused a security issue but was also resulting in incorrect filtering.

2) The Input filters are applied in addition to the ProfileFilters. If the same tag appears in both input and profile filter the AWS apis and it and the result is only the instances that have the input filter. E.g. For the profile above, if the user filters by Role=App1, the Filter sent to AWS will be :

tag:Role :- [ App1, App2 ]
tag:Role :- [ App1 ]

Which will result in instances with tag Role=App1. Which is the required behavior.

3) If a tag is not assigned to any Profiles given to user and the user tries to filter by it we add it to final filter criteria. Because of fix one above it will make sure that only instances lying withing the profile gets pulled always. 

Thanks,
Pramod.