### PR TITLE
Fix: squid:S2293: The operator ("<>") should be used.

### DIFF
--- a/src/main/java/com/ec2box/common/util/AppConfig.java
+++ b/src/main/java/com/ec2box/common/util/AppConfig.java
@@ -68,7 +68,7 @@ public class AppConfig {
     public static Map<String,String> getMapProperties(String name) {
 
         String values= prop.getString(name);
-        Map<String,String> map= new LinkedHashMap<String, String>();
+        Map<String,String> map= new LinkedHashMap<>();
 
         for(String set:values.split(";")){
             String key=set.split(",")[0];

--- a/src/main/java/com/ec2box/manage/action/OTPAction.java
+++ b/src/main/java/com/ec2box/manage/action/OTPAction.java
@@ -100,7 +100,7 @@ public class OTPAction extends ActionSupport implements ServletRequestAware, Ser
 
             QRCodeWriter qrWriter = new QRCodeWriter();
 
-            Hashtable<EncodeHintType, String> hints = new Hashtable<EncodeHintType, String>();
+            Hashtable<EncodeHintType, String> hints = new Hashtable<>();
             hints.put(EncodeHintType.CHARACTER_SET, "UTF-8");
 
 

--- a/src/main/java/com/ec2box/manage/action/SecureShellAction.java
+++ b/src/main/java/com/ec2box/manage/action/SecureShellAction.java
@@ -52,11 +52,11 @@ public class SecureShellAction extends ActionSupport implements ServletRequestAw
     String password;
     String passphrase;
     Integer id;
-    List<HostSystem> systemList = new ArrayList<HostSystem>();
-    List<HostSystem> allocatedSystemList = new ArrayList<HostSystem>();
+    List<HostSystem> systemList = new ArrayList<>();
+    List<HostSystem> allocatedSystemList = new ArrayList<>();
     UserSettings userSettings;
 
-    static Map<Long, UserSchSessions> userSchSessionMap = new ConcurrentHashMap<Long, UserSchSessions>();
+    static Map<Long, UserSchSessions> userSchSessionMap = new ConcurrentHashMap<>();
 
 
     Script script = new Script();

--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -77,7 +77,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
         String userType = AuthUtil.getUserType(servletRequest.getSession());
 
         List<String> ec2RegionList = EC2KeyDB.getEC2Regions();
-        List<String> instanceIdList = new ArrayList<String>();
+        List<String> instanceIdList = new ArrayList<>();
         
         //default instance state
         if(sortedSet.getFilterMap().get(FILTER_BY_INSTANCE_STATE) == null){
@@ -85,7 +85,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
         }
 
         try {
-            Map<String, HostSystem> hostSystemList = new HashMap<String, HostSystem>();
+            Map<String, HostSystem> hostSystemList = new HashMap<>();
 
             //if user profile has been set or user is a manager
             List<Profile> profileList = UserProfileDB.getProfilesByUser(userId);
@@ -140,7 +140,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
 
 
                             //only return systems that have keys set
-                            List<String> keyValueList = new ArrayList<String>();
+                            List<String> keyValueList = new ArrayList<>();
                             for (EC2Key ec2Key : EC2KeyDB.getEC2KeyByRegion(ec2Region, awsCred.getId())) {
                                 keyValueList.add(ec2Key.getKeyNm());
                             }
@@ -152,7 +152,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
 
                             //instance state filter
                             if (StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_INSTANCE_STATE))) {
-                                List<String> instanceStateList = new ArrayList<String>();
+                                List<String> instanceStateList = new ArrayList<>();
                                 instanceStateList.add(sortedSet.getFilterMap().get(FILTER_BY_INSTANCE_STATE));
                                 Filter instanceStateFilter = new Filter("instance-state-name", instanceStateList);
                                 describeInstancesRequest.withFilters(instanceStateFilter);
@@ -163,7 +163,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                                 describeInstancesRequest.withFilters(groupFilter);
                             }
                             //set name value pair for tag filter
-                            List<String> tagList = new ArrayList<String>();
+                            List<String> tagList = new ArrayList<>();
                             for (String tag : tagMap.keySet()) {
                                 if(tagMap.get(tag) != null) {
                                     Filter tagValueFilter = new Filter("tag:" + tag, tagMap.get(tag));
@@ -213,11 +213,11 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
 
                             if (instanceIdList.size() > 0) {
                                 //set instance id list to check permissions when creating sessions
-                                servletRequest.getSession().setAttribute("instanceIdList", new ArrayList<String>(instanceIdList));
+                                servletRequest.getSession().setAttribute("instanceIdList", new ArrayList<>(instanceIdList));
                                 if(showStatus) {
                                     //make service call 100 instances at a time b/c of AWS limitation
                                     int i = 0;
-                                    List<String> idCallList = new ArrayList<String>();
+                                    List<String> idCallList = new ArrayList<>();
                                     while (!instanceIdList.isEmpty()) {
                                         idCallList.add(instanceIdList.remove(0));
                                         i++;
@@ -297,7 +297,7 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
 
                 //set ec2 systems
                 SystemDB.setSystems(hostSystemList.values());
-                sortedSet = SystemDB.getSystemSet(sortedSet, new ArrayList<String>(hostSystemList.keySet()));
+                sortedSet = SystemDB.getSystemSet(sortedSet, new ArrayList<>(hostSystemList.keySet()));
 
             }
         } catch (

--- a/src/main/java/com/ec2box/manage/action/UploadAndPushAction.java
+++ b/src/main/java/com/ec2box/manage/action/UploadAndPushAction.java
@@ -39,7 +39,7 @@ public class UploadAndPushAction extends ActionSupport implements ServletRequest
     File upload;
     String uploadContentType;
     String uploadFileName;
-    List<Long> idList = new ArrayList<Long>();
+    List<Long> idList = new ArrayList<>();
     String pushDir = "~";
     List<HostSystem> hostSystemList;
     HostSystem pendingSystemStatus;

--- a/src/main/java/com/ec2box/manage/action/UserProfileAction.java
+++ b/src/main/java/com/ec2box/manage/action/UserProfileAction.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class UserProfileAction extends ActionSupport {
 
-    List<Profile> profileList = new ArrayList<Profile>();
+    List<Profile> profileList = new ArrayList<>();
     User user;
     Long profileId;
 

--- a/src/main/java/com/ec2box/manage/db/AWSCredDB.java
+++ b/src/main/java/com/ec2box/manage/db/AWSCredDB.java
@@ -47,7 +47,7 @@ public class AWSCredDB {
     public static SortedSet getAWSCredSet(SortedSet sortedSet) {
 
 
-        List<AWSCred> awsCredList = new ArrayList<AWSCred>();
+        List<AWSCred> awsCredList = new ArrayList<>();
 
 
         String orderBy = "";
@@ -101,7 +101,7 @@ public class AWSCredDB {
     public static List<AWSCred> getAWSCredList() {
 
 
-        List<AWSCred> awsCredList = new ArrayList<AWSCred>();
+        List<AWSCred> awsCredList = new ArrayList<>();
 
 
         Connection con = null;

--- a/src/main/java/com/ec2box/manage/db/EC2KeyDB.java
+++ b/src/main/java/com/ec2box/manage/db/EC2KeyDB.java
@@ -45,7 +45,7 @@ public class EC2KeyDB {
      */
     public static SortedSet getEC2KeySet( SortedSet sortedSet) {
 
-        List<EC2Key> ec2KeyList = new ArrayList<EC2Key>();
+        List<EC2Key> ec2KeyList = new ArrayList<>();
 
 
         String orderBy = "";
@@ -174,7 +174,7 @@ public class EC2KeyDB {
      * @return key information
      */
     public static List<EC2Key> getEC2KeyByRegion(String ec2Region, Long awsCredId) {
-        List<EC2Key> ec2KeyList = new ArrayList<EC2Key>();
+        List<EC2Key> ec2KeyList = new ArrayList<>();
 
         Connection con = null;
         try {
@@ -325,7 +325,7 @@ public class EC2KeyDB {
      */
     public static List<String> getEC2Regions() {
 
-        List<String> ec2RegionList = new ArrayList<String>();
+        List<String> ec2RegionList = new ArrayList<>();
 
         Connection con = null;
         try {

--- a/src/main/java/com/ec2box/manage/db/ProfileDB.java
+++ b/src/main/java/com/ec2box/manage/db/ProfileDB.java
@@ -39,7 +39,7 @@ public class ProfileDB {
      */
     public static SortedSet getProfileSet(SortedSet sortedSet) {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
 
         String orderBy = "";
         if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -81,7 +81,7 @@ public class ProfileDB {
      */
     public static List<Profile> getAllProfiles() {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
         Connection con = null;
         try {
             con = DBUtils.getConn();

--- a/src/main/java/com/ec2box/manage/db/ScriptDB.java
+++ b/src/main/java/com/ec2box/manage/db/ScriptDB.java
@@ -42,7 +42,7 @@ public class ScriptDB {
      */
     public static SortedSet getScriptSet(SortedSet sortedSet, Long userId) {
 
-        ArrayList<Script> scriptList = new ArrayList<Script>();
+        ArrayList<Script> scriptList = new ArrayList<>();
 
 
         String orderBy = "";

--- a/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
@@ -91,7 +91,7 @@ public class SessionAuditDB {
     public static SortedSet getSessions(SortedSet sortedSet) {
         //get db connection
         Connection con = null;
-        List<SessionAudit> outputList = new LinkedList<SessionAudit>();
+        List<SessionAudit> outputList = new LinkedList<>();
 
         String orderBy = "";
         if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -274,7 +274,7 @@ public class SessionAuditDB {
      */
     public static List<SessionOutput> getTerminalLogsForSession(Connection con, Long sessionId, Long hostSystemId) {
 
-        List<SessionOutput> outputList = new LinkedList<SessionOutput>();
+        List<SessionOutput> outputList = new LinkedList<>();
         try {
             PreparedStatement stmt = con.prepareStatement("select * from terminal_log where system_id=? and session_id=? order by log_tm asc");
             stmt.setLong(1, hostSystemId);
@@ -321,7 +321,7 @@ public class SessionAuditDB {
      */
     public static List<HostSystem> getHostSystemsForSession(Connection con, Long sessionId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         try {
             PreparedStatement stmt = con.prepareStatement("select distinct system_id from terminal_log where session_id=?");
             stmt.setLong(1, sessionId);

--- a/src/main/java/com/ec2box/manage/db/SystemDB.java
+++ b/src/main/java/com/ec2box/manage/db/SystemDB.java
@@ -52,7 +52,7 @@ public class SystemDB {
      * @return sortedSet with list of host systems
      */
     public static SortedSet getSystemSet(SortedSet sortedSet, List<String> instanceIdList) {
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
 
         if (!instanceIdList.isEmpty()) {
 
@@ -388,7 +388,7 @@ public class SystemDB {
 
         Connection con = null;
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         for(String instanceId: instanceIdList){
 
             try {

--- a/src/main/java/com/ec2box/manage/db/SystemStatusDB.java
+++ b/src/main/java/com/ec2box/manage/db/SystemStatusDB.java
@@ -49,7 +49,7 @@ public class SystemStatusDB {
 
                 //make sure selected instance id is host the user has permission to.
                 List<String> instanceIdList= (List<String>)servletRequest.getSession().getAttribute("instanceIdList");
-                List<Long> systemIdList = new ArrayList<Long>();
+                List<Long> systemIdList = new ArrayList<>();
                 for (HostSystem hostSystem : SystemDB.getSystems(instanceIdList)) {
                     if (systemSelectIds.contains(hostSystem.getId())) {
                         systemIdList.add(hostSystem.getId());
@@ -182,7 +182,7 @@ public class SystemStatusDB {
      */
     public static List<HostSystem> getAllSystemStatus(Long userId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         Connection con = null;
         try {
             con = DBUtils.getConn();
@@ -204,7 +204,7 @@ public class SystemStatusDB {
      */
     private static List<HostSystem> getAllSystemStatus(Connection con, Long userId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         try {
 
             PreparedStatement stmt = con.prepareStatement("select * from status where user_id=? order by id asc");

--- a/src/main/java/com/ec2box/manage/db/UserDB.java
+++ b/src/main/java/com/ec2box/manage/db/UserDB.java
@@ -48,7 +48,7 @@ public class UserDB {
      */
     public static SortedSet getUserSet(SortedSet sortedSet) {
 
-        ArrayList<User> userList = new ArrayList<User>();
+        ArrayList<User> userList = new ArrayList<>();
 
 
         String orderBy = "";

--- a/src/main/java/com/ec2box/manage/db/UserProfileDB.java
+++ b/src/main/java/com/ec2box/manage/db/UserProfileDB.java
@@ -99,7 +99,7 @@ public class UserProfileDB {
 
 
         Connection con = null;
-        List<Profile> profileList = new ArrayList<Profile>();
+        List<Profile> profileList = new ArrayList<>();
         try {
             con = DBUtils.getConn();
             profileList = getProfilesByUser(con, userId);
@@ -120,7 +120,7 @@ public class UserProfileDB {
      */
     public static List<Profile> getProfilesByUser(Connection con, Long userId) {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
 
 
         try {
@@ -154,7 +154,7 @@ public class UserProfileDB {
 
 
         Connection con = null;
-        List<User> userList = new ArrayList<User>();
+        List<User> userList = new ArrayList<>();
         try {
             con = DBUtils.getConn();
             userList = getUsersByProfile(con, profileId);
@@ -176,7 +176,7 @@ public class UserProfileDB {
      */
     public static List<User> getUsersByProfile(Connection con, Long profileId) {
 
-        ArrayList<User> userList = new ArrayList<User>();
+        ArrayList<User> userList = new ArrayList<>();
 
 
         try {

--- a/src/main/java/com/ec2box/manage/model/UserSchSessions.java
+++ b/src/main/java/com/ec2box/manage/model/UserSchSessions.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class UserSchSessions {
 
-    Map<Integer, SchSession> schSessionMap = new ConcurrentHashMap<Integer, SchSession>();
+    Map<Integer, SchSession> schSessionMap = new ConcurrentHashMap<>();
 
 
     public Map<Integer, SchSession> getSchSessionMap() {

--- a/src/main/java/com/ec2box/manage/model/UserSessionsOutput.java
+++ b/src/main/java/com/ec2box/manage/model/UserSessionsOutput.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class UserSessionsOutput {
 
     //instance id, host output
-    Map<Integer, SessionOutput> sessionOutputMap = new ConcurrentHashMap<Integer,SessionOutput>();
+    Map<Integer, SessionOutput> sessionOutputMap = new ConcurrentHashMap<>();
 
 
     public Map<Integer, SessionOutput> getSessionOutputMap() {

--- a/src/main/java/com/ec2box/manage/socket/SecureShellWS.java
+++ b/src/main/java/com/ec2box/manage/socket/SecureShellWS.java
@@ -161,7 +161,7 @@ public class SecureShellWS {
     /**
      * Maps key press events to the ascii values
      */
-    static Map<Integer, byte[]> keyMap = new HashMap<Integer, byte[]>();
+    static Map<Integer, byte[]> keyMap = new HashMap<>();
 
     static {
         //ESC

--- a/src/main/java/com/ec2box/manage/util/SessionOutputUtil.java
+++ b/src/main/java/com/ec2box/manage/util/SessionOutputUtil.java
@@ -39,7 +39,7 @@ public class SessionOutputUtil {
     private static Logger log = LoggerFactory.getLogger(SessionOutputUtil.class);
 
 
-    private static Map<Long, UserSessionsOutput> userSessionsOutputMap = new ConcurrentHashMap<Long, UserSessionsOutput>();
+    private static Map<Long, UserSessionsOutput> userSessionsOutputMap = new ConcurrentHashMap<>();
     public static boolean enableInternalAudit = "true".equals(AppConfig.getProperty("enableInternalAudit"));
     private static Gson gson = new GsonBuilder().registerTypeAdapter(AuditWrapper.class, new SessionOutputSerializer()).create();
     private static Logger systemAuditLogger = LoggerFactory.getLogger("com.ec2box.manage.util.SystemAudit");
@@ -116,7 +116,7 @@ public class SessionOutputUtil {
      * @return session output list
      */
     public static List<SessionOutput> getOutput(Connection con, Long sessionId, User user) {
-        List<SessionOutput> outputList = new ArrayList<SessionOutput>();
+        List<SessionOutput> outputList = new ArrayList<>();
 
         UserSessionsOutput userSessionsOutput = userSessionsOutputMap.get(sessionId);
         if (userSessionsOutput != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator (""<>"") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293
 Please let me know if you have any questions.
 Ayman Elkfrawy.