### PR TITLE
Fix: squid:S1118: Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/ec2box/common/util/AppConfig.java
+++ b/src/main/java/com/ec2box/common/util/AppConfig.java
@@ -28,6 +28,9 @@ public class AppConfig {
 
     private static ResourceBundle prop = ResourceBundle.getBundle("EC2BoxConfig");
 
+    private AppConfig() {
+    }
+
     /**
      * gets the property from config
      *

--- a/src/main/java/com/ec2box/common/util/AuthUtil.java
+++ b/src/main/java/com/ec2box/common/util/AuthUtil.java
@@ -26,6 +26,9 @@ import java.util.Calendar;
 public class AuthUtil {
 
 
+    private AuthUtil() {
+    }
+
     /**
      * query session for OTP shared secret
      *

--- a/src/main/java/com/ec2box/manage/db/AWSCredDB.java
+++ b/src/main/java/com/ec2box/manage/db/AWSCredDB.java
@@ -37,6 +37,9 @@ public class AWSCredDB {
 
     public static final String SORT_BY_ACCESS_KEY = "access_key";
 
+    private AWSCredDB() {
+    }
+
 
     /**
      * returns list of all amazon credentials

--- a/src/main/java/com/ec2box/manage/db/AuthDB.java
+++ b/src/main/java/com/ec2box/manage/db/AuthDB.java
@@ -29,6 +29,9 @@ import java.util.UUID;
  */
 public class AuthDB {
 
+    private AuthDB() {
+    }
+
     /**
      * returns admin login object based on auth token
      *

--- a/src/main/java/com/ec2box/manage/db/EC2KeyDB.java
+++ b/src/main/java/com/ec2box/manage/db/EC2KeyDB.java
@@ -37,6 +37,9 @@ public class EC2KeyDB {
     public static final String SORT_BY_EC2_REGION="ec2_region";
     public static final String SORT_BY_ACCESS_KEY="access_key";
 
+    private EC2KeyDB() {
+    }
+
     /**
      * returns private key information for user
      *

--- a/src/main/java/com/ec2box/manage/db/ProfileDB.java
+++ b/src/main/java/com/ec2box/manage/db/ProfileDB.java
@@ -33,6 +33,9 @@ public class ProfileDB {
 
     public static final String SORT_BY_PROFILE_NM="nm";
 
+    private ProfileDB() {
+    }
+
     /**
      * method to do order by based on the sorted set object for profiles
      * @return list of profiles

--- a/src/main/java/com/ec2box/manage/db/ScriptDB.java
+++ b/src/main/java/com/ec2box/manage/db/ScriptDB.java
@@ -33,6 +33,9 @@ public class ScriptDB {
 
     public static final String SORT_BY_DISPLAY_NM="display_nm";
 
+    private ScriptDB() {
+    }
+
 
     /**
      * returns scripts based on sort order defined

--- a/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
@@ -48,6 +48,9 @@ public class SessionAuditDB {
     public static final String SORT_BY_USERNAME = "username";
     public static final String SORT_BY_SESSION_TM = "session_tm";
 
+    private SessionAuditDB() {
+    }
+
 
     /**
      * deletes audit history for users if after time set in properties file

--- a/src/main/java/com/ec2box/manage/db/SystemDB.java
+++ b/src/main/java/com/ec2box/manage/db/SystemDB.java
@@ -43,6 +43,9 @@ public class SystemDB {
     public static final String SORT_BY_SYSTEM_STATUS= "system_status";
     public static final String SORT_BY_ALARMS= "alarms";
 
+    private SystemDB() {
+    }
+
 
     /**
      * method to do order by based on the sorted set object for systems. only selects instance IDs in provided list.

--- a/src/main/java/com/ec2box/manage/db/SystemStatusDB.java
+++ b/src/main/java/com/ec2box/manage/db/SystemStatusDB.java
@@ -33,6 +33,9 @@ import java.util.List;
  */
 public class SystemStatusDB {
 
+    private SystemStatusDB() {
+    }
+
     /**
      * set the initial status for selected systems
      *

--- a/src/main/java/com/ec2box/manage/db/UserDB.java
+++ b/src/main/java/com/ec2box/manage/db/UserDB.java
@@ -41,6 +41,9 @@ public class UserDB {
     public static final String SORT_BY_USERNAME="username";
     public static final String SORT_BY_USER_TYPE="user_type";
 
+    private UserDB() {
+    }
+
     /**
      * returns users based on sort order defined
      * @param sortedSet object that defines sort order

--- a/src/main/java/com/ec2box/manage/db/UserProfileDB.java
+++ b/src/main/java/com/ec2box/manage/db/UserProfileDB.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public class UserProfileDB {
 
+    private UserProfileDB() {
+    }
+
     /**
      * add profile for given user
      * @param profileId profile id

--- a/src/main/java/com/ec2box/manage/db/UserThemeDB.java
+++ b/src/main/java/com/ec2box/manage/db/UserThemeDB.java
@@ -28,6 +28,9 @@ import java.sql.ResultSet;
  */
 public class UserThemeDB {
 
+    private UserThemeDB() {
+    }
+
     /**
      * get user theme
      *

--- a/src/main/java/com/ec2box/manage/util/AWSClientConfig.java
+++ b/src/main/java/com/ec2box/manage/util/AWSClientConfig.java
@@ -58,6 +58,9 @@ public class AWSClientConfig {
 
     }
 
+    private AWSClientConfig() {
+    }
+
     /**
      * return configuration information for AWS client
      * @return client configuration information

--- a/src/main/java/com/ec2box/manage/util/DBUtils.java
+++ b/src/main/java/com/ec2box/manage/util/DBUtils.java
@@ -31,6 +31,9 @@ public class DBUtils {
 
     private static Logger log = LoggerFactory.getLogger(DBUtils.class);
 
+    private DBUtils() {
+    }
+
     /**
      * returns DB connection
      *

--- a/src/main/java/com/ec2box/manage/util/DSPool.java
+++ b/src/main/java/com/ec2box/manage/util/DSPool.java
@@ -38,6 +38,9 @@ public class DSPool {
     private static  int MIN_IDLE = Integer.parseInt(AppConfig.getProperty("minIdle"));
     private static int MAX_WAIT = Integer.parseInt(AppConfig.getProperty("maxWait"));
 
+    private DSPool() {
+    }
+
 
     /**
      * fetches the data source for H2 db

--- a/src/main/java/com/ec2box/manage/util/EncryptionUtil.java
+++ b/src/main/java/com/ec2box/manage/util/EncryptionUtil.java
@@ -35,6 +35,9 @@ public class EncryptionUtil {
     //secret key
     private static final byte[] key = new byte[]{'t', '3', '2', 'm', 'p', 'd', 'M', 'O', 'i', '8', 'x', 'z', 'a', 'P', 'o', 'd'};
 
+    private EncryptionUtil() {
+    }
+
     /**
      * generate salt for hash
      *

--- a/src/main/java/com/ec2box/manage/util/OTPUtil.java
+++ b/src/main/java/com/ec2box/manage/util/OTPUtil.java
@@ -47,6 +47,9 @@ public class OTPUtil {
     //interval for validation token change
     private static final int CHANGE_INTERVAL = 30;
 
+    private OTPUtil() {
+    }
+
 
     /**
      * generates OPT secret

--- a/src/main/java/com/ec2box/manage/util/PasswordUtil.java
+++ b/src/main/java/com/ec2box/manage/util/PasswordUtil.java
@@ -32,7 +32,10 @@ public class PasswordUtil {
 
         private static Pattern pattern = Pattern.compile(PASSWORD_REGEX);
 
-        /**
+    private PasswordUtil() {
+    }
+
+    /**
          * Validation to ensure strong password
          *
          * @param password password 

--- a/src/main/java/com/ec2box/manage/util/SSHUtil.java
+++ b/src/main/java/com/ec2box/manage/util/SSHUtil.java
@@ -41,6 +41,9 @@ public class SSHUtil {
 
     public static final int SERVER_ALIVE_INTERVAL = StringUtils.isNumeric(AppConfig.getProperty("serverAliveInterval")) ? Integer.parseInt(AppConfig.getProperty("serverAliveInterval")) * 1000 : 60 * 1000;
 
+    private SSHUtil() {
+    }
+
     /**
      * distributes uploaded item to system defined
      *

--- a/src/main/java/com/ec2box/manage/util/SessionOutputUtil.java
+++ b/src/main/java/com/ec2box/manage/util/SessionOutputUtil.java
@@ -44,6 +44,9 @@ public class SessionOutputUtil {
     private static Gson gson = new GsonBuilder().registerTypeAdapter(AuditWrapper.class, new SessionOutputSerializer()).create();
     private static Logger systemAuditLogger = LoggerFactory.getLogger("com.ec2box.manage.util.SystemAudit");
 
+    private SessionOutputUtil() {
+    }
+
 
     /**
      * removes session for user session


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
 Ayman Elkfrawy.