### PR TITLE
Fix: squid:S1643: Strings should not be concatenated using '+' in a loop

### DIFF
--- a/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
@@ -283,10 +283,12 @@ public class SessionAuditDB {
             stmt.setLong(1, hostSystemId);
             stmt.setLong(2, sessionId);
             ResultSet rs = stmt.executeQuery();
-            String output = "";
+            StringBuilder outputBuilder = new StringBuilder("");
             while (rs.next()) {
-                output = output + rs.getString("output");
+                outputBuilder.append(rs.getString("output"));
             }
+
+            String output = outputBuilder.toString();
 
             output = output.replaceAll("(\\u0007|\u001B\\[K)", "");
             while (output.contains("\b")) {

--- a/src/main/java/com/ec2box/manage/db/SystemDB.java
+++ b/src/main/java/com/ec2box/manage/db/SystemDB.java
@@ -63,18 +63,18 @@ public class SystemDB {
             if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
                 orderBy = " order by " + sortedSet.getOrderByField() + " " + sortedSet.getOrderByDirection();
             }
-            String sql = "select *, CONCAT_WS('-',m_alarm,m_insufficient_data,m_ok) as alarms from  system  where instance_id in ( ";
+            StringBuilder sqlBuilder = new StringBuilder("select *, CONCAT_WS('-',m_alarm,m_insufficient_data,m_ok) as alarms from  system  where instance_id in ( ");
             for (int i = 0; i < instanceIdList.size(); i++) {
-                if (i == instanceIdList.size() - 1) sql = sql + "'" + instanceIdList.get(i) + "') ";
-                else sql = sql + "'" + instanceIdList.get(i) + "', ";
+                if (i == instanceIdList.size() - 1) sqlBuilder.append("'").append(instanceIdList.get(i)).append("') ");
+                else sqlBuilder.append("'").append(instanceIdList.get(i)).append("', ");
             }
 
-            sql = sql + orderBy;
+            sqlBuilder.append(orderBy);
 
             Connection con = null;
             try {
                 con = DBUtils.getConn();
-                PreparedStatement stmt = con.prepareStatement(sql);
+                PreparedStatement stmt = con.prepareStatement(sqlBuilder.toString());
 
                 ResultSet rs = stmt.executeQuery();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings should not be concatenated using '+' in a loop”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1643
 Please let me know if you have any questions.
Ayman Elkfrawy