### PR TITLE
Multiple code fixes for sonar rules: squid:S1871,squid:UselessParenth…

### DIFF
--- a/src/main/java/com/ec2box/common/filter/AuthFilter.java
+++ b/src/main/java/com/ec2box/common/filter/AuthFilter.java
@@ -70,9 +70,8 @@ public class AuthFilter implements Filter {
             String userType = AuthDB.isAuthorized(authToken);
             if (userType != null) {
                 String uri = servletRequest.getRequestURI();
-                if (Auth.MANAGER.equals(userType)) {
-                    isAdmin = true;
-                } else if (uri.matches("^"+servletRequest.getContextPath().replaceAll("/","\\\\/")+"\\/admin\\/.*") && Auth.ADMINISTRATOR.equals(userType)) {
+                if (Auth.MANAGER.equals(userType)
+                        || uri.matches("^"+servletRequest.getContextPath().replaceAll("/","\\\\/")+"\\/admin\\/.*") && Auth.ADMINISTRATOR.equals(userType)) {
                     isAdmin = true;
                 }
                 AuthUtil.setUserType(servletRequest.getSession(), userType);
@@ -106,7 +105,7 @@ public class AuthFilter implements Filter {
         //if not admin redirect to login page
         if (!isAdmin) {
             AuthUtil.deleteAllSession(servletRequest.getSession());
-            servletResponse.sendRedirect((servletRequest.getContextPath() + "/login.action"));
+            servletResponse.sendRedirect(servletRequest.getContextPath() + "/login.action");
         } else {
             chain.doFilter(req, resp);
         }

--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -257,13 +257,10 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                                                         hostSystem.setMonitorOk(hostSystem.getMonitorOk() + 1);
                                                     }
                                                     //check and filter by alarm state
-                                                    if (StringUtils.isEmpty(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE))) {
-                                                        hostSystemList.put(hostSystem.getInstance(), hostSystem);
-                                                    } else if ("ALARM".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorAlarm() > 0) {
-                                                        hostSystemList.put(hostSystem.getInstance(), hostSystem);
-                                                    } else if ("INSUFFICIENT_DATA".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorInsufficientData() > 0) {
-                                                        hostSystemList.put(hostSystem.getInstance(), hostSystem);
-                                                    } else if ("OK".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorOk() > 0 && hostSystem.getMonitorInsufficientData() <= 0 && hostSystem.getMonitorAlarm() <= 0) {
+                                                    if (StringUtils.isEmpty(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE))
+                                                            || "ALARM".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorAlarm() > 0
+                                                            || ("INSUFFICIENT_DATA".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorInsufficientData() > 0)
+                                                            || ("OK".equals(sortedSet.getFilterMap().get(FILTER_BY_ALARM_STATE)) && hostSystem.getMonitorOk() > 0 && hostSystem.getMonitorInsufficientData() <= 0 && hostSystem.getMonitorAlarm() <= 0)) {
                                                         hostSystemList.put(hostSystem.getInstance(), hostSystem);
                                                     }
                                                 }
@@ -302,16 +299,16 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
             //check against profile
             } else {
                 Map<String,List<String>> tmpMap = parseTags(Arrays.asList(sortedSet.getFilterMap().get(FILTER_BY_TAG)));
-                for(String name : tmpMap.keySet()) {
-
+                for (Map.Entry<String,List<String>> entry: tmpMap.entrySet()) {
+                    String name = entry.getKey();
                     //if profile tags does not have the filtered tag add to filters and it would be ANDed with profile tags.
-                    if(profileTagMap.get(name) == null && tmpMap.get(name) !=null) {
-                        filterTags.put(name,tmpMap.get(name));
+                    if(profileTagMap.get(name) == null && entry.getValue() !=null) {
+                        filterTags.put(name, entry.getValue());
                     }
 
                     //if profile tags have the filtered tag add to filters only if values are contained in allowed list of the user.
-                    if(profileTagMap.get(name) != null && tmpMap.get(name) !=null && profileTagMap.get(name).containsAll(tmpMap.get(name))) {
-                        filterTags.put(name,tmpMap.get(name));
+                    if(profileTagMap.get(name) != null && entry.getValue() !=null && profileTagMap.get(name).containsAll(entry.getValue())) {
+                        filterTags.put(name,entry.getValue());
                     }
                 }
             }

--- a/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/ec2box/manage/db/SessionAuditDB.java
@@ -68,7 +68,7 @@ public class SessionAuditDB {
 
             //take today's date and subtract how many days to keep history
             Calendar cal = Calendar.getInstance();
-            cal.add(Calendar.DATE, (-1 * Integer.parseInt(AppConfig.getProperty("deleteAuditLogAfter")))); //subtract
+            cal.add(Calendar.DATE, -1 * Integer.parseInt(AppConfig.getProperty("deleteAuditLogAfter"))); //subtract
             java.sql.Date date = new java.sql.Date(cal.getTimeInMillis());
 
 

--- a/src/main/java/com/ec2box/manage/socket/SecureShellWS.java
+++ b/src/main/java/com/ec2box/manage/socket/SecureShellWS.java
@@ -123,9 +123,9 @@ public class SecureShellWS {
             if (userSchSessions != null) {
                 Map<Integer, SchSession> schSessionMap = userSchSessions.getSchSessionMap();
 
-                for (Integer sessionKey : schSessionMap.keySet()) {
-
-                    SchSession schSession = schSessionMap.get(sessionKey);
+                  for (Map.Entry<Integer, SchSession> entry : schSessionMap.entrySet()) {
+                    Integer sessionKey = entry.getKey();
+                    SchSession schSession = entry.getValue();
 
                     //disconnect ssh session
                     schSession.getChannel().disconnect();

--- a/src/main/java/com/ec2box/manage/util/OTPUtil.java
+++ b/src/main/java/com/ec2box/manage/util/OTPUtil.java
@@ -124,7 +124,7 @@ public class OTPUtil {
         }
 
 
-        return (calculated != -1 && calculated == token);
+        return calculated != -1 && calculated == token;
 
 
     }


### PR DESCRIPTION
This pull request fixes the following sonar rules:
**squid:S1871**: Two branches in the same conditional structure should not have exactly the same implementation
**squid:UselessParenthesesCheck**: Useless parentheses around expressions should be removed to prevent any misunderstanding
**squid:S2864**: "entrySet()" should be iterated when both the key and value are needed

You can find more details about them here:
https://dev.eclipse.org/sonar/coding_rules#rule_key=squid:S1871
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#rule_key=squid%3AS2864|s=createdAt|asc=false

Please let me know if you have any questions.
Ayman Elkfrawy.