### PR TITLE
Strict-Transport-Security and X-Frame-Options headers are added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ target/*
 .idea/*
 *.iml
 *.DS_Store
+/.project
+/.classpath
+/.settings/
+/target/

--- a/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
+++ b/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
@@ -1,0 +1,35 @@
+package com.ec2box.common.interceptor;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.StrutsStatics;
+
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.ActionInvocation;
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+
+public class ClickjackingInterceptor extends AbstractInterceptor {
+
+	/**
+	 * Clickjacking, also known as a "UI redress attack", is when an attacker
+	 * uses multiple transparent or opaque layers to trick a user into clicking
+	 * on a button or link on another page when they were intending to click on
+	 * the the top level page. Thus, the attacker is "hijacking" clicks meant
+	 * for their page and routing them to another page, most likely owned by
+	 * another application, domain, or both.
+	 * https://www.owasp.org/index.php/Clickjacking
+	 */
+
+	private static final long serialVersionUID = 2438421386123540997L;
+	private static final String HEADER = "X-Frame-Options";
+	private static final String VALUE = "DENY";
+	
+	@Override
+	public String intercept(ActionInvocation invocation) throws Exception {
+		ActionContext context = invocation.getInvocationContext();
+		HttpServletResponse response = (HttpServletResponse) context.get(StrutsStatics.HTTP_RESPONSE);
+		String headerValue = VALUE;
+		response.addHeader(HEADER, headerValue);
+		return invocation.invoke();
+	}
+}

--- a/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
+++ b/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
@@ -22,7 +22,7 @@ public class ClickjackingInterceptor extends AbstractInterceptor {
 
 	private static final long serialVersionUID = 2438421386123540997L;
 	private static final String HEADER = "X-Frame-Options";
-	private static final String VALUE = "DENY";
+	private static final String VALUE = "SAMEORIGIN";
 	
 	@Override
 	public String intercept(ActionInvocation invocation) throws Exception {

--- a/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
+++ b/src/main/java/com/ec2box/common/interceptor/ClickjackingInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ec2box.common.interceptor;
 
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/com/ec2box/common/interceptor/HTTPStrictTransportSecurityInterceptor.java
+++ b/src/main/java/com/ec2box/common/interceptor/HTTPStrictTransportSecurityInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ec2box.common.interceptor;
 
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/com/ec2box/common/interceptor/HTTPStrictTransportSecurityInterceptor.java
+++ b/src/main/java/com/ec2box/common/interceptor/HTTPStrictTransportSecurityInterceptor.java
@@ -1,0 +1,39 @@
+package com.ec2box.common.interceptor;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.StrutsStatics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.ActionInvocation;
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+
+public class HTTPStrictTransportSecurityInterceptor extends AbstractInterceptor {
+
+	/**
+	 * HTTP Strict Transport Security (HSTS) is an opt-in security enhancement
+	 * that is specified by a web application through the use of a special
+	 * response header. Once a supported browser receives this header that
+	 * browser will prevent any communications from being sent over HTTP to the
+	 * specified domain and will instead send all communications over HTTPS. It
+	 * also prevents HTTPS click through prompts on browsers.
+	 * https://www.owasp.org/index.php/HTTP_Strict_Transport_Security
+	 */
+
+	private static final long serialVersionUID = 6937154325400922939L;
+	private static final String HEADER = "Strict-Transport-Security";
+	private static final String MAX_AGE = "max-age=";
+	private static final int ONE_YEAR = 31536000;
+
+	@Override
+	public String intercept(ActionInvocation invocation) throws Exception {
+		ActionContext context = invocation.getInvocationContext();
+		HttpServletResponse response = (HttpServletResponse) context.get(StrutsStatics.HTTP_RESPONSE);
+		String headerValue = MAX_AGE + ONE_YEAR;
+		response.addHeader(HEADER, headerValue);
+		return invocation.invoke();
+	}
+
+}

--- a/src/main/java/com/ec2box/manage/action/AWSCredAction.java
+++ b/src/main/java/com/ec2box/manage/action/AWSCredAction.java
@@ -24,6 +24,7 @@ import com.ec2box.manage.model.SortedSet;
 import com.ec2box.manage.util.AWSClientConfig;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.SessionAware;
 
@@ -32,6 +33,7 @@ import java.util.Map;
 /**
  * Action to set aws credentials
  */
+@InterceptorRef("ec2boxStack")
 public class AWSCredAction extends ActionSupport {
 
     AWSCred awsCred;

--- a/src/main/java/com/ec2box/manage/action/EC2KeyAction.java
+++ b/src/main/java/com/ec2box/manage/action/EC2KeyAction.java
@@ -30,6 +30,7 @@ import com.ec2box.manage.util.AWSClientConfig;
 import com.google.gson.Gson;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletResponseAware;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import java.util.*;
 /**
  * Action to import private key for EC2 instances
  */
+@InterceptorRef("ec2boxStack")
 public class EC2KeyAction extends ActionSupport implements ServletResponseAware {
 
     public static final String REQUIRED = "Required";

--- a/src/main/java/com/ec2box/manage/action/LoginAction.java
+++ b/src/main/java/com/ec2box/manage/action/LoginAction.java
@@ -23,6 +23,8 @@ import com.ec2box.manage.util.OTPUtil;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
+import org.apache.struts2.convention.annotation.InterceptorRefs;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 import org.slf4j.Logger;
@@ -34,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Action to login to ec2box
  */
+@InterceptorRef("ec2boxStack")
 public class LoginAction extends ActionSupport implements ServletRequestAware {
 
     HttpServletRequest servletRequest;

--- a/src/main/java/com/ec2box/manage/action/OTPAction.java
+++ b/src/main/java/com/ec2box/manage/action/OTPAction.java
@@ -25,6 +25,7 @@ import com.ec2box.manage.db.UserDB;
 import com.ec2box.manage.util.OTPUtil;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 import org.apache.struts2.interceptor.ServletResponseAware;
@@ -40,6 +41,7 @@ import java.net.URLEncoder;
 import java.util.Date;
 import java.util.Hashtable;
 
+@InterceptorRef("ec2boxStack")
 public class OTPAction extends ActionSupport implements ServletRequestAware, ServletResponseAware {
 
     private static Logger log = LoggerFactory.getLogger(OTPAction.class);

--- a/src/main/java/com/ec2box/manage/action/ProfileAction.java
+++ b/src/main/java/com/ec2box/manage/action/ProfileAction.java
@@ -21,11 +21,13 @@ import com.ec2box.manage.model.SortedSet;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 
 
 /**
  * Action to create user profiles
  */
+@InterceptorRef("ec2boxStack")
 public class ProfileAction extends ActionSupport {
     Profile profile;
     SortedSet sortedSet = new SortedSet();

--- a/src/main/java/com/ec2box/manage/action/ScriptAction.java
+++ b/src/main/java/com/ec2box/manage/action/ScriptAction.java
@@ -22,6 +22,7 @@ import com.ec2box.manage.model.Script;
 import com.ec2box.manage.model.SortedSet;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 
@@ -30,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Action to manage scripts
  */
+@InterceptorRef("ec2boxStack")
 public class ScriptAction extends ActionSupport implements ServletRequestAware {
 
     SortedSet sortedSet = new SortedSet();

--- a/src/main/java/com/ec2box/manage/action/SecureShellAction.java
+++ b/src/main/java/com/ec2box/manage/action/SecureShellAction.java
@@ -22,6 +22,7 @@ import com.ec2box.manage.model.*;
 import com.ec2box.manage.util.SSHUtil;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 import org.apache.struts2.interceptor.ServletResponseAware;
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * This action will create composite ssh terminals to be used
  */
+@InterceptorRef("ec2boxStack")
 public class SecureShellAction extends ActionSupport implements ServletRequestAware, ServletResponseAware {
 
     private static Logger log = LoggerFactory.getLogger(SecureShellAction.class);

--- a/src/main/java/com/ec2box/manage/action/SessionAuditAction.java
+++ b/src/main/java/com/ec2box/manage/action/SessionAuditAction.java
@@ -22,6 +22,7 @@ import com.ec2box.manage.model.SortedSet;
 import com.google.gson.Gson;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletResponseAware;
 import org.slf4j.Logger;
@@ -32,6 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Action to audit sessions and terminal history
  */
+@InterceptorRef("ec2boxStack")
 public class SessionAuditAction extends ActionSupport implements ServletResponseAware {
 
     private static Logger log = LoggerFactory.getLogger(SessionAuditAction.class);

--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -33,6 +33,7 @@ import com.ec2box.manage.util.AWSClientConfig;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ import java.util.*;
 /**
  * Action to manage systems
  */
+@InterceptorRef("ec2boxStack")
 public class SystemAction extends ActionSupport implements ServletRequestAware {
 
     private static Logger log = LoggerFactory.getLogger(SystemAction.class);

--- a/src/main/java/com/ec2box/manage/action/UploadAndPushAction.java
+++ b/src/main/java/com/ec2box/manage/action/UploadAndPushAction.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.AgeFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 
@@ -33,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.util.*;
 
+@InterceptorRef("ec2boxStack")
 public class UploadAndPushAction extends ActionSupport implements ServletRequestAware {
 
 

--- a/src/main/java/com/ec2box/manage/action/UserProfileAction.java
+++ b/src/main/java/com/ec2box/manage/action/UserProfileAction.java
@@ -23,6 +23,7 @@ import com.ec2box.manage.model.Profile;
 import com.ec2box.manage.model.User;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import java.util.List;
 /**
  * Action to assign profiles to users
  */
+@InterceptorRef("ec2boxStack")
 public class UserProfileAction extends ActionSupport {
 
     List<Profile> profileList = new ArrayList<>();

--- a/src/main/java/com/ec2box/manage/action/UserSettingsAction.java
+++ b/src/main/java/com/ec2box/manage/action/UserSettingsAction.java
@@ -23,6 +23,7 @@ import com.ec2box.manage.model.UserSettings;
 import com.ec2box.manage.util.PasswordUtil;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 
@@ -31,6 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Action for user settings
  */
+@InterceptorRef("ec2boxStack")
 public class UserSettingsAction extends ActionSupport implements ServletRequestAware {
 
     public static final String REQUIRED = "Required";

--- a/src/main/java/com/ec2box/manage/action/UsersAction.java
+++ b/src/main/java/com/ec2box/manage/action/UsersAction.java
@@ -23,6 +23,7 @@ import com.ec2box.manage.model.User;
 import com.ec2box.manage.util.PasswordUtil;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.InterceptorRef;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.interceptor.ServletRequestAware;
 import javax.servlet.http.HttpServletRequest;
@@ -30,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Action to manage users
  */
+@InterceptorRef("ec2boxStack")
 public class UsersAction extends ActionSupport  implements ServletRequestAware {
 
     public static final String REQUIRED = "Required";

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -48,11 +48,6 @@
         <appender-ref ref="login-appender"/>
     </logger>
 
-	<logger name="com.ec2box.common.interceptor.HTTPStrictTransportSecurityInterceptor" additivity="false">
-        <level value="info"/>
-        <appender-ref ref="login-appender"/>
-    </logger>
-
     <root>
         <level value="warn"/>
         <appender-ref ref="console"/>

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -48,6 +48,11 @@
         <appender-ref ref="login-appender"/>
     </logger>
 
+	<logger name="com.ec2box.common.interceptor.HTTPStrictTransportSecurityInterceptor" additivity="false">
+        <level value="info"/>
+        <appender-ref ref="login-appender"/>
+    </logger>
+
     <root>
         <level value="warn"/>
         <appender-ref ref="console"/>

--- a/src/main/resources/struts.xml
+++ b/src/main/resources/struts.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE struts PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 2.5//EN" "http://struts.apache.org/dtds/struts-2.5.dtd">
+<struts>
+	<package name="default" namespace="/" extends="struts-default">
+
+		<interceptors>
+			<interceptor name="HSTS" class="com.ec2box.common.interceptor.HTTPStrictTransportSecurityInterceptor" />
+			<interceptor name="Clickjacking" class="com.ec2box.common.interceptor.ClickjackingInterceptor" />
+			
+			<interceptor-stack name="ec2boxStack">
+				<interceptor-ref name="HSTS" />
+				<interceptor-ref name="Clickjacking" />
+				<interceptor-ref name="defaultStack"/>
+			</interceptor-stack>
+		</interceptors>
+
+	</package>
+	
+    <constant name="struts.convention.default.parent.package" value="default"/>
+</struts>


### PR DESCRIPTION
Two vulnerabilities have been identified during pentesting: 
1.Missing HSTS Header
2.Clickjacking(UI Redress)

Two interceptors are added to code base, they will intercept all actions by the help of 'InterceptorRef' annotation. They basically add missing "Strict-Transport-Security" and "X-Frame-Options" HTTP headers to response with "max-age=31536000" and "DENY" values respectively.
 
 