### PR TITLE
Add support getting user value from configured tag name

### DIFF
--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -187,6 +187,8 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                                     for (Tag tag : instance.getTags()) {
                                         if ("Name".equals(tag.getKey())) {
                                             hostSystem.setDisplayNm(tag.getValue());
+                                        } else if  (AppConfig.getProperty("userTagName").equals(tag.getKey())) {
+                                            hostSystem.setUser(tag.getValue());
                                         }
                                     }
                                     instanceIdList.add(hostSystem.getInstance());

--- a/src/main/resources/EC2BoxConfig.properties
+++ b/src/main/resources/EC2BoxConfig.properties
@@ -60,3 +60,5 @@ maxWait=15000
 dbOptions=AUTO_SERVER=TRUE;
 #The session time out value of application in minutes
 sessionTimeout=15
+# The optional tag on an instance that defines the host user to use
+userTagName=ec2box-user


### PR DESCRIPTION
When setting up Host system connect information, use the user specified in an ec2 tag on the instance  (default to tag 'ec2-user) if found.