### PR TITLE
add option to prefer private_ip host connections

### DIFF
--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -169,7 +169,8 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                                     HostSystem hostSystem = new HostSystem();
                                     hostSystem.setInstance(instance.getInstanceId());
 
-                                    //check for public dns if doesn't exist set to ip or pvt dns
+                                    // (optionally) use private_ip configured, otherwise
+                                    // check for public dns if doesn't exist set to ip or pvt dns
                                     if ("true".equals(AppConfig.getProperty("useEC2PvtIP"))) {
                                         hostSystem.setHost(instance.getPrivateIpAddress());
                                     } else if (!"true".equals(AppConfig.getProperty("useEC2PvtDNS")) && StringUtils.isNotEmpty(instance.getPublicDnsName())) {

--- a/src/main/java/com/ec2box/manage/action/SystemAction.java
+++ b/src/main/java/com/ec2box/manage/action/SystemAction.java
@@ -170,7 +170,9 @@ public class SystemAction extends ActionSupport implements ServletRequestAware {
                                     hostSystem.setInstance(instance.getInstanceId());
 
                                     //check for public dns if doesn't exist set to ip or pvt dns
-                                    if (!"true".equals(AppConfig.getProperty("useEC2PvtDNS")) && StringUtils.isNotEmpty(instance.getPublicDnsName())) {
+                                    if ("true".equals(AppConfig.getProperty("useEC2PvtIP"))) {
+                                        hostSystem.setHost(instance.getPrivateIpAddress());
+                                    } else if (!"true".equals(AppConfig.getProperty("useEC2PvtDNS")) && StringUtils.isNotEmpty(instance.getPublicDnsName())) {
                                         hostSystem.setHost(instance.getPublicDnsName());
                                     } else if (!"true".equals(AppConfig.getProperty("useEC2PvtDNS")) && StringUtils.isNotEmpty(instance.getPublicIpAddress())) {
                                         hostSystem.setHost(instance.getPublicIpAddress());

--- a/src/main/resources/EC2BoxConfig.properties
+++ b/src/main/resources/EC2BoxConfig.properties
@@ -30,6 +30,8 @@ websocketTimeout=0
 agentForwarding=false
 #Use private DNS for instances
 useEC2PvtDNS=false
+#Use private IP for instances
+useEC2PvtIP=false
 #enable two-factor authentication
 enableOTP=true
 #Regular expression to enforce password policy


### PR DESCRIPTION
This offers a solution for those who requires connections to be made to remote instances using their private_ip address.